### PR TITLE
remove height because it is getting stretched out

### DIFF
--- a/src/styles/components/GridComponent.css
+++ b/src/styles/components/GridComponent.css
@@ -1,6 +1,5 @@
 .grid-component {
   width: 100%;
-  height: 100%;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;


### PR DESCRIPTION
this is due to primary layout using flex space between to layout the header and footer.